### PR TITLE
Added Scaffolder backend module for new backend system support

### DIFF
--- a/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/README.md
+++ b/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/README.md
@@ -13,10 +13,30 @@ This plugin provides scaffolder actions to create AWS resources and utility acti
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/backend @aws/plugin-scaffolder-backend-aws-apps-for-backstage@0.2.0
+yarn add --cwd packages/backend @aws/plugin-scaffolder-backend-aws-apps-for-backstage
 ```
 
 ## Configuration
+
+### New backend system
+
+```ts
+// packages/backend/src/index.ts
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+...
+
+// scaffolder backend modules
+backend.add(import('@aws/plugin-scaffolder-backend-aws-apps-for-backstage'))
+
+...
+
+backend.start();
+```
+
+### Legacy backend
 
 Configure the action(s) you would like to use in your Backstage app.
 

--- a/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/src/index.ts
+++ b/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/src/index.ts
@@ -9,3 +9,4 @@
  */
 
 export * from './actions';
+export { scaffolderModuleAwsApps as default } from './module'

--- a/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/src/module.ts
+++ b/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/src/module.ts
@@ -1,0 +1,51 @@
+import {
+    coreServices,
+    createBackendModule,
+  } from '@backstage/backend-plugin-api';
+  import { CatalogClient } from '@backstage/catalog-client';
+  import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node/alpha';
+  import { ScmIntegrations } from '@backstage/integration';
+  import {
+    createRepoAccessTokenAction,
+    createSecretAction,
+    createS3BucketAction,
+    getEnvProvidersAction,
+    getComponentInfoAction,
+    getSsmParametersAction,
+    getPlatformParametersAction,
+    getPlatformMetadataAction,
+  } from './actions';
+  
+  /** @public */
+  export const scaffolderModuleAwsApps = createBackendModule({
+    pluginId: 'scaffolder', // name of the plugin that the module is targeting
+    moduleId: 'aws-apps',
+    register(env) {
+      env.registerInit({
+        deps: {
+          scaffolder: scaffolderActionsExtensionPoint,
+          config: coreServices.rootConfig,
+          discovery: coreServices.discovery,
+        },
+        async init({ scaffolder, config, discovery }) {
+          const integrations = ScmIntegrations.fromConfig(config);
+          const catalogClient = new CatalogClient({
+            discoveryApi: discovery,
+          });
+          scaffolder.addActions(createS3BucketAction());
+          scaffolder.addActions(createSecretAction({ envConfig: config }));
+          scaffolder.addActions(getEnvProvidersAction({ catalogClient }));
+          scaffolder.addActions(getComponentInfoAction());
+          scaffolder.addActions(getSsmParametersAction());
+          scaffolder.addActions(getPlatformMetadataAction({ envConfig: config }));
+          scaffolder.addActions(
+            getPlatformParametersAction({ envConfig: config }),
+          );
+          scaffolder.addActions(
+            createRepoAccessTokenAction({ integrations, envConfig: config }),
+          );
+        },
+      });
+    },
+  });
+  


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

New backend system support for the `@aws/plugin-scaffolder-backend-aws-apps-for-backstage` 

### Motivation

<!-- What inspired you to submit this pull request? -->

Enable declarative configuration for the module instead writing the extension class directly in the `packages/backend/src/index.ts` [see](https://github.com/awslabs/harmonix/blob/59f8c22a45ae4c1d8eb0a5892493529afe1ed1e1/backstage-mods/backstage_0.5.17.diff.patch#L874).

example:

```typescript
// packages/backend/src/index.ts

backend.add(import('@aws/plugin-scaffolder-backend-aws-apps-for-backstage')
```

### For Moderators

- [ ] Compile, build, tests successful before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Relates to issue: https://github.com/awslabs/harmonix/issues/116