### PR TITLE
feat(resource-binding): Create a file with a security group ID

### DIFF
--- a/backstage-plugins/plugins/aws-apps-backend/src/api/aws-platform.ts
+++ b/backstage-plugins/plugins/aws-apps-backend/src/api/aws-platform.ts
@@ -301,6 +301,12 @@ export class AwsAppsPlatformApi {
       content: resourceBindContent,
     });
 
+    input.securityGroupIds.forEach((securityGroupId) => actions.push({
+      action: 'create',
+      file_path: `.iac/security-groups/${input.envName}/${input.providerName}/${securityGroupId}`,
+      content: ''
+    }))
+
     const change:ICommitChange = {
       commitMessage: `Bind Resource`,
       branch: 'main',
@@ -351,6 +357,12 @@ export class AwsAppsPlatformApi {
       file_path: resourceBindFile,
       content: resourceBindContent,
     });
+
+    input.securityGroupIds.forEach((securityGroupId) => actions.push({
+      action: 'delete',
+      file_path: `.iac/security-groups/${input.envName}/${input.providerName}/${securityGroupId}`,
+      content: ''
+    }))
 
     const change:ICommitChange = {
       commitMessage: `UnBind Resource`,

--- a/backstage-plugins/plugins/aws-apps-backend/src/service/router.ts
+++ b/backstage-plugins/plugins/aws-apps-backend/src/service/router.ts
@@ -309,13 +309,15 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
     const resourceName = req.body.resourceName?.toString();
     const resourceEntityRef = req.body.resourceEntityRef?.toString();
     const policies = req.body.policies;
+    const securityGroupIds = req.body.securityGroupIds || [];
     const params: BindResourceParams = {
       envName,
       appName,
       providerName,
       resourceName,
       resourceEntityRef,
-      policies
+      policies,
+      securityGroupIds
     };
     // console.log(params)
     const results = await apiPlatformClient.bindResource(repoInfo,params, secretName);
@@ -337,12 +339,14 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
     const resourceName = req.body.resourceName?.toString();
     const resourceEntityRef = req.body.resourceEntityRef?.toString();
     const policies = req.body.policies;
+    const securityGroupIds = req.body.securityGroupIds || [];
     const params: BindResourceParams = {
       envName,
       appName,
       providerName,
       resourceName,
       resourceEntityRef,
+      securityGroupIds,
       policies
     };
     // console.log(params)

--- a/backstage-plugins/plugins/aws-apps-common/src/types/AWSResource.ts
+++ b/backstage-plugins/plugins/aws-apps-common/src/types/AWSResource.ts
@@ -39,6 +39,7 @@ export interface ResourceBinding {
   provider: string;
   resourceArn: string;
   associatedResources?: AssociatedResources[]
+  securityGroupIds?: string[]
   entityRef?:string;
 }
 
@@ -55,6 +56,7 @@ export interface BindResourceParams {
   resourceName:string;
   resourceEntityRef:string;
   policies: ResourcePolicy[];
+  securityGroupIds: string[];
   appName: string;
 }
 

--- a/backstage-plugins/plugins/aws-apps/src/api/OPAApiClient.ts
+++ b/backstage-plugins/plugins/aws-apps/src/api/OPAApiClient.ts
@@ -229,7 +229,8 @@ export class OPAApiClient implements OPAApi {
       envName: params.envName,
       policies: params.policies,
       resourceName: params.resourceName,
-      resourceEntityRef: params.resourceEntityRef
+      resourceEntityRef: params.resourceEntityRef,
+      securityGroupIds: params.securityGroupIds
     }
 
     const bindResponse = this.fetch<any>('/platform/bind-resource', HTTP.POST, postBody);
@@ -259,7 +260,8 @@ export class OPAApiClient implements OPAApi {
       envName: params.envName,
       policies: params.policies,
       resourceName: params.resourceName,
-      resourceEntityRef: params.resourceEntityRef
+      resourceEntityRef: params.resourceEntityRef,
+      securityGroupIds: params.securityGroupIds
     }
 
     const unBindResponse = this.fetch<any>('/platform/unbind-resource', HTTP.POST, postBody);

--- a/backstage-plugins/plugins/aws-apps/src/components/ResourceBindingCard/ResourceBinding.tsx
+++ b/backstage-plugins/plugins/aws-apps/src/components/ResourceBindingCard/ResourceBinding.tsx
@@ -98,6 +98,7 @@ const ResourceBindingCard = ({
               resourceArn: providerAppData['Arn'],
               id: providerAppData['Arn'],
               entityRef: "resource:default/" + et!.metadata.name,
+              securityGroupIds: providerAppData['AccessSecurityGroupId'] ? [providerAppData['AccessSecurityGroupId']] : [],
               associatedResources: [associatedRDSResources]
             })
         }
@@ -173,6 +174,7 @@ const ResourceBindingCard = ({
       appName: entity.metadata.name,
       resourceName: item.resourceName,
       resourceEntityRef: item.id,
+      securityGroupIds: item.securityGroupIds || [],
       policies
     };
 
@@ -214,6 +216,7 @@ const ResourceBindingCard = ({
       appName: entity.metadata.name,
       resourceName: item.resourceName,
       resourceEntityRef: item.entityRef!,
+      securityGroupIds: item.securityGroupIds || [],
       policies
     };
 

--- a/backstage-plugins/plugins/aws-apps/src/components/ResourceBindingCard/ResourceSelectorDialog.tsx
+++ b/backstage-plugins/plugins/aws-apps/src/components/ResourceBindingCard/ResourceSelectorDialog.tsx
@@ -183,6 +183,7 @@ export const ResourceSelectorDialog = ({
               provider: p,
               resourceArn: providerAppData['Arn'],
               id,
+              securityGroupIds: providerAppData['AccessSecurityGroupId'] ? [providerAppData['AccessSecurityGroupId']] : [],
               associatedResources: [associatedRDSResources]
             })
         }


### PR DESCRIPTION
Create a file with a security group ID when it is defined as AccessSecurityGroupId in the resource manifest

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

Resource binding currently supports adding IAM statements to application roles so they can execute AWS API operations on a given resource.

My goal is to also make it possible to bind a given security group (provided in a resource manifest via the `appData.AccessSecurityGroupId`) which would give networking access to the resource from the application.

The file created in the application's `.iac` directory would then be read by the CDK stack to add said security group to the ECS service/EKS pod security group policy.

### For Moderators

- [ ] Compile, build, tests successful before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
