### PR TITLE
fix(rds): update Aurora PostgreSQL version to supported version

### DIFF
--- a/iac/roots/opa-common-constructs/src/rds-construct.ts
+++ b/iac/roots/opa-common-constructs/src/rds-construct.ts
@@ -36,7 +36,7 @@ export class RdsConstruct extends Construct {
 
     this.cluster = new rds.DatabaseCluster(this, `${envIdentifier}db`, {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
-        version: rds.AuroraPostgresEngineVersion.VER_13_7,
+        version: rds.AuroraPostgresEngineVersion.VER_13_9, // Changed to a supported version
       }),
       defaultDatabaseName: `${envIdentifier}db`,
       credentials: rds.Credentials.fromGeneratedSecret("postgres", {


### PR DESCRIPTION
### What does this PR do?

This PR resolves an issue where the AWS CDK RDS construct was using Aurora PostgreSQL version 13.7, which is no longer supported.

Fixes implemented:

Replaced VER_13_7 with VER_13_9  engine version.

### Motivation

AWS has deprecated PostgreSQL 13.7 for Aurora, causing CDK deployment failures (ROLLBACK_COMPLETE).

### Additional Notes
1. This PR addresses [Issue #149](https://github.com/awslabs/harmonix/issues/149).
2. After merging, deployments should work without modifications for AWS-supported PostgreSQL versions.
