### PR TITLE
Make VPC CIDR configurable for hosting Backstage

### DIFF
--- a/config/sample.env
+++ b/config/sample.env
@@ -64,6 +64,9 @@ R53_HOSTED_ZONE_NAME="TODO"
 # Only use 0.0.0.0/0 if you are certain that alternative implementations (firewalls, network routing) will prevent unintended access.
 ALLOWED_IPS="TODO"
 
+# Specifies the CIDR range for the VPC that hosts Backstage
+BACKSTAGE_NETWORK_CIDR_RANGE="10.0.0.0/16"
+
 # Okta Identity Provider Configurations
 # See RoadieHQ documentation for details: https://www.npmjs.com/package/@roadiehq/catalog-backend-module-okta
 OKTA_API_TOKEN="TODO"

--- a/iac/roots/opa-platform/src/opa-platform-stack.ts
+++ b/iac/roots/opa-platform/src/opa-platform-stack.ts
@@ -104,7 +104,7 @@ export class OPAPlatformStack extends cdk.Stack {
     // Create VPC for hosting backstage
     const network = new NetworkConstruct(this, "Backstage-Network", {
       opaEnv: opaParams,
-      cidrRange: "10.0.0.0/16",
+      cidrRange: getEnvVarValue(process.env.BACKSTAGE_NETWORK_CIDR_RANGE) || "10.0.0.0/16",
       isIsolated: false,
       allowedIPs,
       publicVpcNatGatewayCount: +(getEnvVarValue(process.env.NUM_PUBLIC_NATGW) || 3),


### PR DESCRIPTION
### What does this PR do?

This PR makes the VPC CIDR range configurable for hosting Backstage by introducing a new environment variable BACKSTAGE_NETWORK_CIDR_RANGE. The default value remains "10.0.0.0/16" if not specified.

### Motivation

The ability to configure VPC CIDR ranges is essential to avoid CIDR overlapping with other VPCs in your AWS environment, which can cause networking conflicts and routing issues. Additionally, it ensures compliance with corporate network addressing policies and standards that may dictate specific CIDR ranges for different environments or applications.

### For Moderators

- [ ] Compile, build, tests successful before merge?
